### PR TITLE
ENT-3372: Renamed main package name from taxonomy-service to taxonomy-connector

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Unreleased
 --------------------
 
 
+[1.1.0] - 2020-09-30
+--------------------
+
+* Renamed main package name from taxonomy-service to taxonomy-connector.
+
 [1.0.1] - 2020-09-21
 --------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ source_suffix = '.rst'
 top_level_doc = 'index'
 
 # General information about the project.
-project = 'taxonomy-service'
+project = 'taxonomy-connector'
 copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin
 author = edx_theme.AUTHOR
 project_title = 'Open edX Enterprise Service Documentation'
@@ -182,7 +182,7 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
 #
-# html_title = 'taxonomy-service v0.1.0'
+# html_title = 'taxonomy-connector v1.1.0'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,25 +11,25 @@ certifi==2020.6.20        # via -r requirements/test.txt, -r requirements/travis
 chardet==3.0.4            # via -r requirements/test.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.7.0   # via -r requirements/test.txt
+code-annotations==0.9.0   # via -r requirements/test.txt
 codecov==2.1.9            # via -r requirements/travis.txt
-coverage==5.2.1           # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
-diff-cover==4.0.0         # via -r requirements/dev.in
+coverage==5.3             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
+diff-cover==4.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt
 django-solo==1.1.3        # via -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils
 django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-model-utils, djangorestframework, edx-django-utils, edx-i18n-tools
-djangorestframework==3.11.1  # via -r requirements/test.txt
+djangorestframework==3.12.1  # via -r requirements/test.txt
 edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-rest-api-client
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in
 edx-rest-api-client==5.2.1  # via -r requirements/test.txt
 factory-boy==3.0.1        # via -r requirements/test.txt
-faker==4.1.2              # via -r requirements/test.txt, factory-boy
+faker==4.1.3              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/test.txt, -r requirements/travis.txt, requests
-importlib-metadata==1.7.0  # via inflect
+importlib-metadata==2.0.0  # via inflect
 inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/dev.in, pylint
@@ -39,8 +39,8 @@ lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.5.0     # via -r requirements/test.txt, pytest
-newrelic==5.18.0.148      # via -r requirements/test.txt, edx-django-utils
+more-itertools==8.5.0     # via zipp
+newrelic==5.20.0.149      # via -r requirements/test.txt, edx-django-utils
 packaging==20.4           # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via -c requirements/constraints.txt, path.py
@@ -52,7 +52,7 @@ psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/dev.in
 pydocstyle==5.1.1         # via -r requirements/dev.in
-pygments==2.6.1           # via diff-cover
+pygments==2.7.1           # via diff-cover
 pyjwt==1.7.1              # via -r requirements/test.txt, edx-rest-api-client
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
@@ -60,8 +60,8 @@ pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/travis.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==6.0.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==3.10.0     # via -r requirements/test.txt
+pytest==6.1.0             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, faker
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 pytz==2020.1              # via -r requirements/test.txt, django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,23 +8,22 @@ attrs==20.2.0             # via pytest
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via code-annotations
-code-annotations==0.7.0   # via -r requirements/test.in
-coverage==5.2.1           # via pytest-cov
+code-annotations==0.9.0   # via -r requirements/test.in
+coverage==5.3             # via pytest-cov
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-solo==1.1.3        # via -r requirements/base.in
 django-waffle==2.0.0      # via edx-django-utils
-djangorestframework==3.11.1  # via -r requirements/base.in
+djangorestframework==3.12.1  # via -r requirements/base.in
 edx-django-utils==3.8.0   # via -r requirements/base.in, edx-rest-api-client
 edx-rest-api-client==5.2.1  # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
-faker==4.1.2              # via -r requirements/test.in, factory-boy
+faker==4.1.3              # via -r requirements/test.in, factory-boy
 idna==2.10                # via requests
 iniconfig==1.0.1          # via pytest
 jinja2==2.11.2            # via code-annotations
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.5.0     # via pytest
-newrelic==5.18.0.148      # via edx-django-utils
+newrelic==5.20.0.149      # via edx-django-utils
 packaging==20.4           # via pytest
 pbr==5.5.0                # via stevedore
 pluggy==0.13.1            # via pytest
@@ -33,8 +32,8 @@ py==1.9.0                 # via pytest
 pyjwt==1.7.1              # via edx-rest-api-client
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==3.9.0      # via -r requirements/test.in
-pytest==6.0.1             # via pytest-cov, pytest-django
+pytest-django==3.10.0     # via -r requirements/test.in
+pytest==6.1.0             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via faker
 python-slugify==4.0.1     # via code-annotations
 pytz==2020.1              # via -r requirements/base.in, django

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 codecov==2.1.9            # via -r requirements/travis.in
-coverage==5.2.1           # via codecov
+coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C0111,C0103
 """
-Setup configurations for taxonomy application.
+Setup configurations for the taxonomy connector application.
 """
 
 import os
@@ -80,17 +80,17 @@ VERSION = get_version('taxonomy', '__init__.py')
 CHANGELOG = open(os.path.join(base_path, 'CHANGELOG.rst')).read()
 
 setup(
-    name='taxonomy-service',
+    name='taxonomy-connector',
     version=VERSION,
     packages=[
         'taxonomy',
     ],
     include_package_data=True,
-    description='Taxonomy service',
+    description='Taxonomy connector',
     long_description=README + "\n\n" + CHANGELOG,
     author='edX',
     author_email='oscm@edx.org',
-    url='https://github.com/edx/taxonomy-service',
+    url='https://github.com/edx/taxonomy-connector',
     license='MIT',
     install_requires=REQUIREMENTS
 )

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -3,6 +3,6 @@
 Your project description goes here.
 """
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/constants.py
+++ b/taxonomy/constants.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Constants used by the taxonomy service.
+Constants used by the taxonomy connector.
 """
 
 JOBS_QUERY_FILTER = {

--- a/taxonomy/emsi_client.py
+++ b/taxonomy/emsi_client.py
@@ -14,7 +14,7 @@ from slumber.exceptions import SlumberBaseException
 from django.conf import settings
 
 from taxonomy.constants import JOB_POSTINGS_QUERY_FILTER, JOBS_QUERY_FILTER
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ class EMSISkillsApiClient(JwtEMSIApiClient):
 
             return self.traverse_data(response)
         except (SlumberBaseException, ConnectionError, Timeout) as error:
-            raise TaxonomyServiceAPIError('Error while fetching course skills.') from error
+            raise TaxonomyAPIError('Error while fetching course skills.') from error
 
     @staticmethod
     def traverse_data(response):
@@ -194,7 +194,7 @@ class EMSIJobsApiClient(JwtEMSIApiClient):
             response = endpoint().post(query_filter)
             return self.traverse_jobs_data(response)
         except (SlumberBaseException, ConnectionError, Timeout) as error:
-            raise TaxonomyServiceAPIError(
+            raise TaxonomyAPIError(
                 'Error while fetching job rankings for {ranking_facet}/{nested_ranking_facet}.'.format(
                     ranking_facet=ranking_facet.value,
                     nested_ranking_facet=nested_ranking_facet.value,
@@ -226,7 +226,7 @@ class EMSIJobsApiClient(JwtEMSIApiClient):
             response = endpoint().post(query_filter)
             return self.traverse_job_postings_data(response)
         except (SlumberBaseException, ConnectionError, Timeout) as error:
-            raise TaxonomyServiceAPIError(
+            raise TaxonomyAPIError(
                 'Error while fetching job postings data ranked by {ranking_facet}.'.format(
                     ranking_facet=ranking_facet.value,
                 )

--- a/taxonomy/exceptions.py
+++ b/taxonomy/exceptions.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-Exceptions that will be used by the taxonomy service to indicate different errors.
+Exceptions that will be used by the taxonomy connector to indicate different errors.
 """
 
 
-class TaxonomyServiceAPIError(Exception):
+class TaxonomyAPIError(Exception):
     """
     Exception to raise when something goes wrong while talking to the EMSI service.
     """

--- a/taxonomy/management/commands/refresh_course_skills.py
+++ b/taxonomy/management/commands/refresh_course_skills.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext as _
 
 from taxonomy.emsi_client import EMSISkillsApiClient
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import CourseSkills, RefreshCourseSkillsConfig, Skill
 from taxonomy.providers.utils import get_course_metadata_provider
 
@@ -89,8 +89,8 @@ class Command(BaseCommand):
             if course_description:
                 try:
                     course_skills = client.get_course_skills(course_description)
-                except TaxonomyServiceAPIError:
-                    LOGGER.error('Taxonomy Service Error for course_key: %s', course['key'])
+                except TaxonomyAPIError:
+                    LOGGER.error('Taxonomy API Error for course_key: %s', course['key'])
                     failures.add((course['uuid'], course['key']))
                 else:
                     failed_records = self._process_skills_data(course, course_skills, options['commit'])

--- a/taxonomy/management/commands/refresh_job_postings_data.py
+++ b/taxonomy/management/commands/refresh_job_postings_data.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _
 
 from taxonomy.emsi_client import EMSIJobsApiClient
 from taxonomy.enums import RankingFacet
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import Job, JobPostings
 
 LOGGER = logging.getLogger(__name__)
@@ -48,8 +48,8 @@ class Command(BaseCommand):
         client = EMSIJobsApiClient()
         try:
             job_postings_data = client.get_job_postings(RankingFacet[ranking_facet])
-        except TaxonomyServiceAPIError:
-            message = 'Taxonomy Service Error for refreshing the job postings data for ' \
+        except TaxonomyAPIError:
+            message = 'Taxonomy API Error for refreshing the job postings data for ' \
                       'Ranking Facet {}'.format(ranking_facet)
             LOGGER.error(message)
             raise CommandError(message)

--- a/taxonomy/management/commands/refresh_job_skills.py
+++ b/taxonomy/management/commands/refresh_job_skills.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _
 
 from taxonomy.emsi_client import EMSIJobsApiClient
 from taxonomy.enums import RankingFacet
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import Job, JobSkills
 
 LOGGER = logging.getLogger(__name__)
@@ -64,8 +64,8 @@ class Command(BaseCommand):
                 RankingFacet[ranking_facet],
                 RankingFacet[nested_ranking_facet],
             )
-        except TaxonomyServiceAPIError:
-            message = 'Taxonomy Service Error for refreshing the jobs for ' \
+        except TaxonomyAPIError:
+            message = 'Taxonomy API Error for refreshing the jobs for ' \
                       'Ranking Facet {} and Nested Ranking Facet {}'.format(ranking_facet, nested_ranking_facet)
             LOGGER.error(message)
             raise CommandError(message)

--- a/taxonomy/models.py
+++ b/taxonomy/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-ORM Models for taxonomy application.
+ORM Models for the taxonomy application.
 """
 from __future__ import unicode_literals
 

--- a/taxonomy/urls.py
+++ b/taxonomy/urls.py
@@ -1,5 +1,5 @@
 """
-Taxonomy Service URL Configuration.
+Taxonomy Connector URL Configuration.
 """
 
 from django.urls import re_path

--- a/tests/management/test_refresh_course_skills.py
+++ b/tests/management/test_refresh_course_skills.py
@@ -14,7 +14,7 @@ from django.core.management.base import CommandError
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import CourseSkills, RefreshCourseSkillsConfig, Skill
 from test_utils.mocks import MockCourse
 from test_utils.providers import DiscoveryCourseMetadataProvider
@@ -83,7 +83,7 @@ class RefreshCourseSkillsCommandTests(TestCase):
         """
         Test that the command does not create any records when the API throws an exception.
         """
-        get_course_skills_mock.side_effect = TaxonomyServiceAPIError()
+        get_course_skills_mock.side_effect = TaxonomyAPIError()
         skill = Skill.objects.all()
         course_skill = CourseSkills.objects.all()
         self.assertEqual(skill.count(), 0)
@@ -96,7 +96,7 @@ class RefreshCourseSkillsCommandTests(TestCase):
             # Validate a descriptive and readable log message.
             self.assertEqual(len(log_capture.records), 2)
             message = log_capture.records[0].msg
-            self.assertEqual(message, 'Taxonomy Service Error for course_key: %s')
+            self.assertEqual(message, 'Taxonomy API Error for course_key: %s')
 
         self.assertEqual(skill.count(), 0)
         self.assertEqual(course_skill.count(), 0)

--- a/tests/management/test_refresh_job_postings_data.py
+++ b/tests/management/test_refresh_job_postings_data.py
@@ -13,7 +13,7 @@ from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import Job, JobPostings
 from test_utils.sample_responses.job_postings import JOB_POSTINGS, MISSING_MEDIAN_SALARY_JOB_POSTING
 
@@ -63,13 +63,13 @@ class RefreshJobPostingsCommandTests(TestCase):
         """
         Test that the command does not create any records when the API throws an exception.
         """
-        get_job_postings_mock.side_effect = TaxonomyServiceAPIError()
+        get_job_postings_mock.side_effect = TaxonomyAPIError()
         jobs = Job.objects.all()
         job_postings = JobPostings.objects.all()
         self.assertEqual(jobs.count(), 0)
         self.assertEqual(job_postings.count(), 0)
 
-        err_string = _('Taxonomy Service Error for refreshing the job postings data for Ranking Facet TITLE_NAME')
+        err_string = _('Taxonomy API Error for refreshing the job postings data for Ranking Facet TITLE_NAME')
         with LogCapture(level=logging.INFO) as log_capture:
             with self.assertRaisesRegex(CommandError, err_string):
                 call_command(self.command, 'TITLE_NAME')
@@ -78,7 +78,7 @@ class RefreshJobPostingsCommandTests(TestCase):
             message = log_capture.records[0].msg
             self.assertEqual(
                 message,
-                'Taxonomy Service Error for refreshing the job postings data for Ranking Facet TITLE_NAME'
+                'Taxonomy API Error for refreshing the job postings data for Ranking Facet TITLE_NAME'
             )
 
         self.assertEqual(jobs.count(), 0)

--- a/tests/management/test_refresh_job_skills.py
+++ b/tests/management/test_refresh_job_skills.py
@@ -13,7 +13,7 @@ from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.utils.translation import gettext as _
 
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import Job, JobSkills
 from test_utils.sample_responses.jobs import JOBS
 
@@ -58,13 +58,13 @@ class RefreshJobSkillsCommandTests(TestCase):
         """
         Test that the command does not create any records when the API throws an exception.
         """
-        get_job_skills_mock.side_effect = TaxonomyServiceAPIError()
+        get_job_skills_mock.side_effect = TaxonomyAPIError()
         jobs = Job.objects.all()
         job_skills = JobSkills.objects.all()
         self.assertEqual(jobs.count(), 0)
         self.assertEqual(job_skills.count(), 0)
 
-        err_string = _('Taxonomy Service Error for refreshing the jobs for Ranking Facet'
+        err_string = _('Taxonomy API Error for refreshing the jobs for Ranking Facet'
                        ' CERTIFICATIONS and Nested Ranking Facet CERTIFICATIONS_NAME')
         with LogCapture(level=logging.INFO) as log_capture:
             with self.assertRaisesRegex(CommandError, err_string):
@@ -72,7 +72,7 @@ class RefreshJobSkillsCommandTests(TestCase):
             # Validate a descriptive and readable log message.
             self.assertEqual(len(log_capture.records), 1)
             message = log_capture.records[0].msg
-            self.assertEqual(message, 'Taxonomy Service Error for refreshing the jobs for'
+            self.assertEqual(message, 'Taxonomy API Error for refreshing the jobs for'
                                       ' Ranking Facet CERTIFICATIONS and Nested Ranking Facet CERTIFICATIONS_NAME')
 
         self.assertEqual(jobs.count(), 0)

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Tests for the `taxonomy-service` app.
+Tests for the `taxonomy-connector` app.
 """
 
 import taxonomy

--- a/tests/test_emsi_client.py
+++ b/tests/test_emsi_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Tests for the `taxonomy-service` emsi client.
+Tests for the `taxonomy-connector` emsi client.
 """
 
 import logging
@@ -12,7 +12,7 @@ from testfixtures import LogCapture
 
 from taxonomy.emsi_client import EMSIJobsApiClient, EMSISkillsApiClient, JwtEMSIApiClient
 from taxonomy.enums import RankingFacet
-from taxonomy.exceptions import TaxonomyServiceAPIError
+from taxonomy.exceptions import TaxonomyAPIError
 from test_utils.constants import CLIENT_ID, CLIENT_SECRET
 from test_utils.decorators import mock_api_response
 from test_utils.sample_responses.job_postings import JOB_POSTINGS, JOB_POSTINGS_FILTER
@@ -176,7 +176,7 @@ class TestEMSISkillsApiClient(TaxonomyTestCase):
         """
         Validate that the behavior of client when error occurs while fetching skill data.
         """
-        with raises(TaxonomyServiceAPIError, match='Error while fetching course skills.'):
+        with raises(TaxonomyAPIError, match='Error while fetching course skills.'):
             self.client.get_course_skills(SKILL_TEXT_DATA)
 
 
@@ -227,7 +227,7 @@ class TestEMSIJobsApiClient(TaxonomyTestCase):
         Validate that the behavior of client when error occurs while fetching jobs data.
         """
         with raises(
-                TaxonomyServiceAPIError,
+                TaxonomyAPIError,
                 match='Error while fetching job rankings for {ranking_facet}/{nested_ranking_facet}.'.format(
                     ranking_facet=RankingFacet.TITLE_NAME.value,
                     nested_ranking_facet=RankingFacet.SKILLS_NAME.value
@@ -259,7 +259,7 @@ class TestEMSIJobsApiClient(TaxonomyTestCase):
         Validate that the behavior of client when error occurs while fetching job postings data.
         """
         with raises(
-                TaxonomyServiceAPIError,
+                TaxonomyAPIError,
                 match='Error while fetching job postings data ranked by {ranking_facet}.'.format(
                     ranking_facet=RankingFacet.TITLE_NAME.value,
                 )


### PR DESCRIPTION
__Description:__

After the update of the repository name from `taxonomy-service` to `taxonomy-connector`, we also need to update all the occurrences inside the repository. This PR handles these updates.