### PR TITLE
ENT-3897: Fixed TypeError that pops up sometimes while communicating with the EMSI API.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,14 @@ Change Log
 Unreleased
 --------------------
 
+[1.2.0] - 2020-12-24
+--------------------
+
+* Fixed TypeError that pops up sometimes while communicating with the EMSI API.
+
 [1.1.6] - 2020-12-24
 --------------------
+
 * Updated the README description.
 
 [1.1.5] - 2020-12-18

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.1.6'
+__version__ = '1.2.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/test_settings.py
+++ b/test_settings.py
@@ -45,8 +45,12 @@ SECRET_KEY = 'insecure-secret-key'
 
 
 # Settings related to to EMSI client
-EMSI_API_ACCESS_TOKEN_URL = 'https://auth.emsicloud.com/connect/token'
-EMSI_API_BASE_URL = 'https://emsiservices.com'
+# API URLs are altered to avoid accidentally calling the API in tests
+# Original URL: https://auth.emsicloud.com/connect/token
+EMSI_API_ACCESS_TOKEN_URL = 'http://example.com/connect/token'
+
+# Original URL: https://emsiservices.com
+EMSI_API_BASE_URL = 'http://example.com'
 EMSI_CLIENT_ID = ''
 EMSI_CLIENT_SECRET = ''
 

--- a/tests/test_emsi_client.py
+++ b/tests/test_emsi_client.py
@@ -48,9 +48,9 @@ class TestJwtEMSIApiClient(TaxonomyTestCase):
     )
     def test_get_oauth_access_token(self):
         """
-        Validate that `get_oauth_access_token` correctly handles request to fetch access token.
+        Validate that `fetch_oauth_access_token` correctly handles request to fetch access token.
         """
-        token = self.client.get_oauth_access_token(CLIENT_ID, CLIENT_SECRET)
+        token = self.client.fetch_oauth_access_token(CLIENT_ID, CLIENT_SECRET)
         assert token == 'test-token'
 
         # Validate that token is also set in the cache
@@ -65,10 +65,10 @@ class TestJwtEMSIApiClient(TaxonomyTestCase):
     )
     def test_get_oauth_access_token_error(self):
         """
-        Validate that `get_oauth_access_token` correctly handles errors while fetching access token.
+        Validate that `fetch_oauth_access_token` correctly handles errors while fetching access token.
         """
         with LogCapture(level=logging.INFO) as log_capture:
-            token = self.client.get_oauth_access_token(CLIENT_ID, CLIENT_SECRET)
+            token = self.client.fetch_oauth_access_token(CLIENT_ID, CLIENT_SECRET)
             assert token is None
 
             # Validate that token is not set in the cache either
@@ -158,6 +158,25 @@ class TestEMSISkillsApiClient(TaxonomyTestCase):
         url=EMSISkillsApiClient.API_BASE_URL + '/versions/latest/extract',
         json=SKILLS,
     )
+    def test_client_error(self):
+        """
+        Validate that initializing EMSISkillsApiClient does not raise error.
+        """
+        # Initialize once and call the API
+        client = EMSISkillsApiClient()
+        skills = client.get_course_skills(SKILL_TEXT_DATA)
+        assert skills == SKILLS
+
+        # Initialize the client again to simulate error condition.
+        client = EMSISkillsApiClient()
+        skills = client.get_course_skills(SKILL_TEXT_DATA)
+        assert skills == SKILLS
+
+    @mock_api_response(
+        method=responses.POST,
+        url=EMSISkillsApiClient.API_BASE_URL + '/versions/latest/extract',
+        json=SKILLS,
+    )
     def test_get_course_skills(self):
         """
         Validate that the behavior of client while fetching course skills.
@@ -189,8 +208,8 @@ class TestEMSIJobsApiClient(TaxonomyTestCase):
         Instantiate an instance of EMSISkillsApiClient for use inside tests.
         """
         super(TestEMSIJobsApiClient, self).setUp()
-        self.client = EMSIJobsApiClient()
         self.mock_access_token()
+        self.client = EMSIJobsApiClient()
 
     def tearDown(self):
         """


### PR DESCRIPTION
__Description:__
During development, I found that sometimes connecting to EMSI Client raises `TypeError`. This is caused by the `client` attribute on EMSI Client being `None`. 

__Error Message:__
```
E           AttributeError: 'NoneType' object has no attribute 'versions'
```
