### PR TITLE
ENT-4156 | added management command `populate_job_names`

### DIFF
--- a/taxonomy/constants.py
+++ b/taxonomy/constants.py
@@ -8,6 +8,16 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 
 
+def get_lookup_query_filter(external_ids):
+    """
+    Build query filter for the lookup endpoint.
+    """
+    lookup_query_filter = {
+        'ids': external_ids
+    }
+    return lookup_query_filter
+
+
 def get_job_query_filter(skills=None):
     """
     Build job query filter to be used in fetching jobs data from the EMSI Service.

--- a/taxonomy/emsi_client.py
+++ b/taxonomy/emsi_client.py
@@ -178,6 +178,32 @@ class EMSIJobsApiClient(JwtEMSIApiClient):
         super(EMSIJobsApiClient, self).__init__(scope='postings:us')
 
     @JwtEMSIApiClient.refresh_token
+    def get_details(self, ranking_facet, query_filter):
+        """
+        Query the EMSI API for the loopup of the pre-defined filter_query.
+
+        Arguments:
+            ranking_facet (RankingFacet): Data will be fetch for this facet.
+            query_filter (dict): Filters to be sent in the POST data.
+
+        Returns:
+            dict: A dictionary containing details of all the details.
+
+        """
+        url = 'taxonomies/{facet}/lookup'.format(
+            facet=ranking_facet.value,
+        )
+        try:
+            endpoint = getattr(self.client, url)
+            response = endpoint().post(query_filter)
+            return response
+        except (SlumberBaseException, ConnectionError, Timeout) as error:
+            LOGGER.exception('[TAXONOMY] Exception raised while fetching data from EMSI')
+            raise TaxonomyAPIError(
+                'Error while fetching lookup for {ranking_facet}'.format(ranking_facet=ranking_facet.value)
+            ) from error
+
+    @JwtEMSIApiClient.refresh_token
     def get_jobs(self, ranking_facet, nested_ranking_facet, query_filter):
         """
         Query the EMSI API for the jobs of the pre-defined filter_query.

--- a/taxonomy/management/commands/populate_job_names.py
+++ b/taxonomy/management/commands/populate_job_names.py
@@ -1,0 +1,71 @@
+"""
+Management command for populating missing job names by extracting from EMSI.
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+
+from taxonomy.constants import get_lookup_query_filter
+from taxonomy.emsi_client import EMSIJobsApiClient
+from taxonomy.enums import RankingFacet
+from taxonomy.exceptions import TaxonomyAPIError
+from taxonomy.models import Job
+from taxonomy.utils import chunked_queryset
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    command for populating missing job names
+
+    While creating Job object we only populate its id. We need to get all the Job in the system that do no have names.
+
+    Example usage:
+        $ # Update the existing job names.
+        $ ./manage.py populate_job_names
+        """
+    help = 'populating missing Job names in the system.'
+
+    def _update_job(self, job_bucket):
+        """
+        Persist the jobs data in the database.
+        """
+        job_id = job_bucket['id']
+        job_name = job_bucket['properties']['singular_name']
+        Job.objects.update_or_create(external_id=job_id, defaults={'name': job_name})
+
+    def _update_jobs(self):
+        """
+        Updated the Jobs by fetching data from EMSI
+        """
+        client = EMSIJobsApiClient()
+        ranking_facet = RankingFacet.TITLE
+        try:
+            jobs = Job.objects.filter(name='')
+            for chunked_jobs in chunked_queryset(jobs):
+                jobs_external_ids = list(chunked_jobs.values_list('external_id', flat=True))
+                jobs = client.get_details(
+                    ranking_facet=ranking_facet,
+                    query_filter=get_lookup_query_filter(jobs_external_ids)
+                )
+                buckets = jobs['data']
+                for bucket in buckets:
+                    self._update_job(bucket)
+        except TaxonomyAPIError as error:
+            message = 'Taxonomy API Error for updating the jobs for Ranking Facet {} Error: {}'.format(
+                ranking_facet, error
+            )
+            LOGGER.error(message)
+            raise CommandError(message)
+        except KeyError as error:
+            message = f'Missing keys in update Job names. Error: {error}'
+            LOGGER.error(message)
+            raise CommandError(message)
+
+    def handle(self, *args, **options):
+        """
+        Entry point for management command execution.
+        """
+        self._update_jobs()

--- a/test_utils/sample_responses/job_lookup.py
+++ b/test_utils/sample_responses/job_lookup.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Sample responses for job lookup from EMSI service. These will be used in tests.
+"""
+JOB_LOOKUP_FILTER = {
+    "ids": ["15.0", "15.1"]
+}
+
+JOB_LOOKUP = {
+    "data": [
+        {
+            "id": "15.0",
+            "name": "Software Engineers",
+            "properties": {
+                "singular_name": "Software Engineer",
+                "soc2": "15-0000",
+                "soc2_name": "Computer and Mathematical"
+            }
+        },
+        {
+            "id": "15.1",
+            "name": "Project Managers (Computer and Mathematical)",
+            "properties": {
+                "singular_name": "Project Manager (Computer and Mathematical)",
+                "soc2": "15-0000",
+                "soc2_name": "Computer and Mathematical"
+            }
+        }
+    ]
+}
+
+JOB_LOOKUP_MISSING_KEY = {
+    "data": [
+        {
+            "id": "15.0",
+            "name": "Software Engineers",
+            "properties": {
+                # missing `singular_name` key
+                "soc2": "15-0000",
+                "soc2_name": "Computer and Mathematical"
+            }
+        },
+        {
+            "id": "15.1",
+            "name": "Project Managers (Computer and Mathematical)",
+            "properties": {
+                "soc2": "15-0000",
+                "soc2_name": "Computer and Mathematical"
+            }
+        }
+    ]
+}

--- a/tests/management/test_populate_job_names.py
+++ b/tests/management/test_populate_job_names.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the django management command `populate_job_names`.
+"""
+
+import logging
+
+import mock
+import responses
+from ddt import ddt
+from pytest import mark
+from testfixtures import LogCapture
+
+from django.core.management import CommandError, call_command
+
+from taxonomy.exceptions import TaxonomyAPIError
+from taxonomy.models import Job
+from test_utils.factories import JobFactory
+from test_utils.sample_responses.job_lookup import JOB_LOOKUP, JOB_LOOKUP_MISSING_KEY
+from test_utils.testcase import TaxonomyTestCase
+
+
+@ddt
+@mark.django_db
+class UpdateJobNamesCommandTests(TaxonomyTestCase):
+    """
+    Test command `populate_job_names`.
+    """
+
+    command = 'populate_job_names'
+
+    def setUp(self):
+        """
+        Testcase Setup.
+        """
+        self.job_lookup_response = JOB_LOOKUP
+        # creating jobs without names
+        for job_bucket in self.job_lookup_response['data']:
+            Job.objects.create(external_id=job_bucket['id'])
+
+        self.missing_key_job_lookup_response = JOB_LOOKUP_MISSING_KEY
+        self.mock_access_token()
+        super(UpdateJobNamesCommandTests, self).setUp()
+
+    @responses.activate
+    @mock.patch('taxonomy.management.commands.refresh_job_skills.EMSIJobsApiClient.get_details')
+    def test_job_postings_saved(self, get_details_mock):
+        """
+        Test that the command updates.
+        """
+        # creating job with name
+        job_with_name = JobFactory(external_id='test_id', name="test_name")
+        job_with_name_modified_on = job_with_name.modified
+
+        get_details_mock.return_value = self.job_lookup_response
+
+        all_jobs = Job.objects.all()
+        jobs_without_name = Job.objects.filter(name='')
+
+        self.assertEqual(all_jobs.count(), 3)
+        self.assertEqual(jobs_without_name.count(), 2)
+
+        call_command(self.command)
+
+        # asset Job are updated with names
+        self.assertEqual(jobs_without_name.count(), 0)
+        self.assertEqual(all_jobs.count(), 3)
+
+        # asset the existing job with name is not updated.
+        job_with_name.refresh_from_db()
+        self.assertEqual(job_with_name.modified, job_with_name_modified_on)
+
+    @responses.activate
+    @mock.patch('taxonomy.management.commands.refresh_job_skills.EMSIJobsApiClient.get_details')
+    def test_job_postings_not_saved_upon_exception(self, get_details_mock):
+        """
+        Test that the command does not create any records when the API throws an exception.
+        """
+        get_details_mock.side_effect = TaxonomyAPIError("API ERROR")
+        jobs_without_name = Job.objects.filter(name='')
+        self.assertEqual(jobs_without_name.count(), 2)
+
+        err_string = "Taxonomy API Error for updating the jobs for Ranking Facet RankingFacet.TITLE Error: API ERROR"
+        with LogCapture(level=logging.INFO) as log_capture:
+            with self.assertRaisesRegex(CommandError, err_string):
+                call_command(self.command)
+            # Validate a descriptive and readable log message.
+            self.assertEqual(len(log_capture.records), 1)
+            message = log_capture.records[0].msg
+            self.assertEqual(message, err_string)
+
+        self.assertEqual(jobs_without_name.count(), 2)
+
+    @responses.activate
+    @mock.patch('taxonomy.management.commands.refresh_job_skills.EMSIJobsApiClient.get_details')
+    def test_job_postings_not_saved_on_key_error(self, get_details_mock):
+        """
+        Test that the command does not create any records when a key error occurs.
+        """
+        get_details_mock.return_value = self.missing_key_job_lookup_response
+        jobs_without_name = Job.objects.filter(name='')
+        self.assertEqual(jobs_without_name.count(), 2)
+
+        err_string = "Missing keys in update Job names. Error: 'singular_name'"
+        with LogCapture(level=logging.INFO) as log_capture:
+            with self.assertRaisesRegex(CommandError, err_string):
+                call_command(self.command)
+            # Validate a descriptive and readable log message.
+            self.assertEqual(len(log_capture.records), 1)
+            message = log_capture.records[0].msg
+            self.assertEqual(message, err_string)
+
+        self.assertEqual(jobs_without_name.count(), 2)

--- a/tests/test_emsi_client.py
+++ b/tests/test_emsi_client.py
@@ -14,6 +14,7 @@ from taxonomy.emsi_client import EMSIJobsApiClient, EMSISkillsApiClient, JwtEMSI
 from taxonomy.enums import RankingFacet
 from taxonomy.exceptions import TaxonomyAPIError
 from test_utils.decorators import mock_api_response
+from test_utils.sample_responses.job_lookup import JOB_LOOKUP, JOB_LOOKUP_FILTER
 from test_utils.sample_responses.job_postings import JOB_POSTINGS, JOB_POSTINGS_FILTER
 from test_utils.sample_responses.jobs import JOBS, JOBS_FILTER
 from test_utils.sample_responses.skills import SKILL_TEXT_DATA, SKILLS_EMSI_CLIENT_RESPONSE, SKILLS_EMSI_RESPONSE
@@ -245,3 +246,34 @@ class TestEMSIJobsApiClient(TaxonomyTestCase):
                 )
         ):
             self.client.get_job_postings(RankingFacet.TITLE_NAME, JOB_POSTINGS_FILTER)
+
+    @mock_api_response(
+        method=responses.POST,
+        url=EMSIJobsApiClient.API_BASE_URL + '/taxonomies/{}/lookup'.format(RankingFacet.TITLE.value),
+        json=JOB_LOOKUP,
+    )
+    def test_get_details(self):
+        """
+        Validate that the behavior of client while fetching job lookup data.
+        """
+        jobs_details = self.client.get_details(RankingFacet.TITLE, JOB_LOOKUP_FILTER)
+
+        assert jobs_details == JOB_LOOKUP
+
+    @mock_api_response(
+        method=responses.POST,
+        url=EMSIJobsApiClient.API_BASE_URL + '/taxonomies/{}/lookup'.format(RankingFacet.TITLE.value),
+        json=JOB_LOOKUP,
+        status=400,
+    )
+    def test_get_details_error(self):
+        """
+        Validate that the behavior of client when error occurs while fetching job lookup data.
+        """
+        with raises(
+                TaxonomyAPIError,
+                match='Error while fetching lookup for {ranking_facet}'.format(
+                    ranking_facet=RankingFacet.TITLE.value,
+                )
+        ):
+            self.client.get_details(RankingFacet.TITLE, JOB_LOOKUP_FILTER)


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.