### PR TITLE
ENT-4202 | Handled edge cases in `refresh_course_skills` command.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[1.6.2] - 2021-03-12
+--------------------
+
+* Handled edge cases in `refresh_course_skills` command.
+
 [1.6.1] - 2021-03-10
 --------------------
 

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/management/commands/refresh_course_skills.py
+++ b/taxonomy/management/commands/refresh_course_skills.py
@@ -90,15 +90,4 @@ class Command(BaseCommand):
             raise InvalidCommandOptionsError('Either course or all argument must be provided.')
 
         LOGGER.info('[TAXONOMY] Refresh course skills process started.')
-        success_courses_count, skipped_courses_count, failures = utils.refresh_course_skills(courses, options['commit'])
-        LOGGER.info(
-            '[TAXONOMY] Refresh course skills process completed. \n'
-            'Failures: %s \n'
-            'Total Courses Updated Successfully: %s \n'
-            'Total Courses Skipped: %s \n'
-            'Total Failures: %s \n',
-            failures,
-            success_courses_count,
-            skipped_courses_count,
-            len(failures),
-        )
+        utils.refresh_course_skills(courses, options['commit'])


### PR DESCRIPTION
### In This PR:
Handled edge cases in `refresh_course_skills` command
Also removed noise from the logging.


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.