### PR TITLE
ENT-4158: Added a utility method to return serialized skills

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[1.11.2] - 2021-05-28
+---------------------
+
+* Added utility method to return serialized course skills.
+
 [1.11.1] - 2021-04-20
 ---------------------
 

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.11.1'
+__version__ = '1.11.2'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/serializers.py
+++ b/taxonomy/serializers.py
@@ -1,0 +1,21 @@
+"""
+Serializers for taxonomy.
+"""
+
+from rest_framework import serializers
+
+from taxonomy.models import Skill
+
+
+class SkillSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Skill model.
+    """
+
+    class Meta:
+        """
+        Metadata for SkillSerializer.
+        """
+
+        model = Skill
+        fields = ('name', 'description')

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -6,8 +6,27 @@ import logging
 from taxonomy.emsi_client import EMSISkillsApiClient
 from taxonomy.exceptions import TaxonomyAPIError
 from taxonomy.models import CourseSkills, Skill
+from taxonomy.serializers import SkillSerializer
 
 LOGGER = logging.getLogger(__name__)
+
+
+def get_whitelisted_serialized_skills(course_key):
+    """
+    Get a list of serialized course skills.
+
+    Arguments:
+        course_key (str): Key of the course whose course skills need to be returned.
+
+    Returns:
+        (dict): A dictionary containing the following key-value pairs
+            1.  name: 'Skill name'
+            2. description: "Skill Description"
+    """
+    course_skills = get_whitelisted_course_skills(course_key)
+    skills = [course_skill.skill for course_skill in course_skills]
+    serializer = SkillSerializer(skills, many=True)
+    return serializer.data
 
 
 def update_skills_data(course_key, skill_external_id, confidence, skill_data):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -183,3 +183,19 @@ class TestUtils(TaxonomyTestCase):
             )
             skill_ids = [course_skill.skill.id for course_skill in blacklisted_course_skills]
             assert len(skill_ids) == 10
+
+    def test_get_whitelisted_serialized_skills(self):
+        """
+        Validate that `get_whitelisted_serialized_skills` returns serialized skills in expected format.
+        """
+        factories.CourseSkillsFactory.create_batch(2, course_key=COURSE_KEY, is_blacklisted=False)
+        expected_skills = utils.get_whitelisted_course_skills(course_key=COURSE_KEY)
+        expected_serialized_skills = [
+            {
+                'name': expected_skill.skill.name,
+                'description': expected_skill.skill.description
+            } for expected_skill in expected_skills
+        ]
+
+        actual_serialized_skills = utils.get_whitelisted_serialized_skills(course_key=COURSE_KEY)
+        assert actual_serialized_skills == expected_serialized_skills


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.