### PR TITLE
feat: add get_course_jobs util method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[1.12.1] - 2021-08-3
+---------------------
+
+* Add utility method `get_course_jobs` to return job associated with a course.
+
 [1.12.0] - 2021-07-13
 ---------------------
 

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.12.0'
+__version__ = '1.12.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -5,7 +5,7 @@ import logging
 
 from taxonomy.emsi_client import EMSISkillsApiClient
 from taxonomy.exceptions import TaxonomyAPIError
-from taxonomy.models import CourseSkills, Skill
+from taxonomy.models import CourseSkills, JobSkills, Skill
 from taxonomy.serializers import SkillSerializer
 
 LOGGER = logging.getLogger(__name__)
@@ -207,3 +207,23 @@ def get_blacklisted_course_skills(course_key, prefetch_skills=True):
     if prefetch_skills:
         qs = qs.select_related('skill')
     return qs.all()
+
+
+def get_course_jobs(course_key):
+    """
+    Get all the course jobs.
+
+    Arguments:
+        course_key (str): Key of the course whose course skills need to be returned.
+
+    Returns:
+        list: A list of all the course jobs.
+    """
+    course_skills = get_whitelisted_course_skills(course_key)
+    job_skills = JobSkills.objects.select_related(
+        'skill',
+        'job',
+    ).filter(
+        skill__in=[course_skill.skill for course_skill in course_skills]
+    )
+    return list({job_skill.job.name for job_skill in job_skills})


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.