### PR TITLE
ENT-4141: Added APIs for taxonomy connector models.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ omit =
     *admin.py
     *static*
     *templates*
+    *urls.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[1.13.0] - 2021-08-9
+---------------------
+
+* Added Skill, Job and JobPostings viewsets.
+
 [1.12.2] - 2021-08-5
 ---------------------
 

--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,25 @@ To install ``taxonomy-connector``, for example, in Course Discovery, follow thes
 #. Changes made into the taxonomy repository will now be picked up by your host environment.
 
 
-Note:
-In order to communicate with EMSI service, you need to set the values of ``client_id`` and ``client_secret``. These values are picked up from the host environment so you need to pass them in ``.yaml`` file of the host environment.
+Notes:
+
+- In order to communicate with EMSI service, you need to set the values of ``client_id`` and ``client_secret``. These values are picked up from the host environment so you need to pass them in ``.yaml`` file of the host environment.
+- Also, to make taxonomy work, the host platform must add an implementation of data providers written in ``./taxonomy/providers``
+- Taxonomy APIs use throttle rate set in ``DEFAULT_THROTTLE_RATES`` settings by default. Custom Throttle rate can by set by adding ``ScopedRateThrottle`` class in ``DEFAULT_THROTTLE_CLASSES`` settings and ``taxonomy-api-throttle-scope`` key in ``DEFAULT_THROTTLE_RATES``
 
 
-Also, to make taxonomy work, the host platform must add an implementation of data providers written in ``./taxonomy/providers``
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        'DEFAULT_THROTTLE_CLASSES': (
+            'rest_framework.throttling.UserRateThrottle',
+            'rest_framework.throttling.ScopedRateThrottle'
+        ),
+        'DEFAULT_THROTTLE_RATES': {
+            'user': '100/hour',
+            'taxonomy-api-throttle-scope': '60/min',  # custom throttle rate for taxonomy api
+        },
+    }
 
 
 Developer Notes

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.12.2'
+__version__ = '1.13.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/api/urls.py
+++ b/taxonomy/api/urls.py
@@ -1,0 +1,8 @@
+"""
+Taxonomy v1 API URLs.
+"""
+from django.urls import include, path
+
+urlpatterns = [
+    path('v1/', include('taxonomy.api.v1.urls')),
+]

--- a/taxonomy/api/v1/serializers.py
+++ b/taxonomy/api/v1/serializers.py
@@ -1,0 +1,61 @@
+"""
+Taxonomy API serializers.
+"""
+from rest_framework.serializers import ModelSerializer
+
+from taxonomy.models import CourseSkills, Job, JobPostings, JobSkills, Skill
+
+
+class JobSerializer(ModelSerializer):
+
+    class Meta:
+        model = Job
+        fields = '__all__'
+
+
+class SkillSerializer(ModelSerializer):
+
+    class Meta:
+        model = Skill
+        fields = '__all__'
+
+
+class JobSkillSerializer(ModelSerializer):
+    skill = SkillSerializer()
+
+    class Meta:
+        model = JobSkills
+        exclude = ('id', 'created', 'modified', 'job')
+
+
+class JobsListSerializer(ModelSerializer):
+    skills = JobSkillSerializer(source='jobskills_set.all', many=True)
+
+    class Meta:
+        model = Job
+        fields = '__all__'
+        extra_fields = ('skills',)
+
+
+class CourseSkillsSerializer(ModelSerializer):
+
+    class Meta:
+        model = CourseSkills
+        exclude = ('id', 'created', 'modified', 'is_blacklisted', 'skill')
+
+
+class SkillListSerializer(ModelSerializer):
+    courses = CourseSkillsSerializer(source='courseskills_set.all', many=True)
+
+    class Meta:
+        model = Skill
+        fields = '__all__'
+        extra_fields = ('courses',)
+
+
+class JobPostingsSerializer(ModelSerializer):
+    job = JobSerializer()
+
+    class Meta:
+        model = JobPostings
+        fields = '__all__'

--- a/taxonomy/api/v1/urls.py
+++ b/taxonomy/api/v1/urls.py
@@ -1,0 +1,13 @@
+"""
+Taxonomy v1 API URLs.
+"""
+from rest_framework.routers import DefaultRouter
+
+from taxonomy.api.v1.views import JobPostingsViewSet, JobsViewSet, SkillViewSet
+
+router = DefaultRouter()
+router.register(r'skills', SkillViewSet, basename='skill')
+router.register(r'jobs', JobsViewSet, basename='job')
+router.register(r'jobpostings', JobPostingsViewSet, basename='jobposting')
+
+urlpatterns = router.urls

--- a/taxonomy/api/v1/views.py
+++ b/taxonomy/api/v1/views.py
@@ -1,0 +1,68 @@
+"""
+Taxonomy API views.
+"""
+from rest_framework import permissions
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from django.db.models import Prefetch
+
+from taxonomy.api.v1.serializers import JobPostingsSerializer, JobsListSerializer, SkillListSerializer
+from taxonomy.models import CourseSkills, Job, JobPostings, Skill
+
+
+class TaxonomyAPIViewSetMixin:
+    """
+    Taxonomy APIs ViewSet Mixin.
+    """
+    permission_classes = (permissions.IsAuthenticated,)
+    throttle_scope = 'taxonomy-api-throttle-scope'
+
+
+class SkillViewSet(TaxonomyAPIViewSetMixin, RetrieveModelMixin, ListModelMixin, GenericViewSet):
+    """
+    ViewSet to list and retrieve all Skills in the system.
+    """
+
+    serializer_class = SkillListSerializer
+
+    def get_queryset(self):
+        """
+        Get all the skills with prefetch_related objects.
+        """
+        return Skill.objects.all().prefetch_related(
+            Prefetch(
+                'courseskills_set',
+                queryset=CourseSkills.objects.filter(is_blacklisted=False)
+            )
+        )
+
+
+class JobsViewSet(TaxonomyAPIViewSetMixin, RetrieveModelMixin, ListModelMixin, GenericViewSet):
+    """
+    ViewSet to list and retrieve all Jobs in the system.
+    """
+    serializer_class = JobsListSerializer
+
+    def get_queryset(self):
+        """
+        Get all the jobs with prefetch_related objects.
+        """
+        return Job.objects.all().prefetch_related(
+            'jobskills_set', 'jobskills_set__skill'
+        )
+
+
+class JobPostingsViewSet(TaxonomyAPIViewSetMixin, RetrieveModelMixin, ListModelMixin, GenericViewSet):
+    """
+    ViewSet to list and retrieve all JobPostings in the system.
+    """
+    serializer_class = JobPostingsSerializer
+
+    def get_queryset(self):
+        """
+        Get all the jobpostings with prefetch_related objects.
+        """
+        return JobPostings.objects.all().select_related(
+            'job'
+        )

--- a/taxonomy/urls.py
+++ b/taxonomy/urls.py
@@ -1,0 +1,8 @@
+"""
+Taxonomy v1 API URLs.
+"""
+from django.urls import include, path
+
+urlpatterns = [
+    path('api/', include('taxonomy.api.urls')),
+]


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.