### PR TITLE
WS-2162: Added a limit of 20 embedded records per job to limit records size.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 --------------------
 
+[1.14.2] - 2021-09-08
+---------------------
+
+* Fixed an issue that was causing an error while index jobs data to algolia.
+
 [1.14.1] - 2021-08-20
 ---------------------
 

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.14.1'
+__version__ = '1.14.2'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/algolia/constants.py
+++ b/taxonomy/algolia/constants.py
@@ -18,3 +18,6 @@ ALGOLIA_JOBS_INDEX_SETTINGS = {
 }
 
 JOBS_PAGE_SIZE = 1
+
+# This is the the maximum number of objects that should be embedded inside an algolia record.
+EMBEDDED_OBJECT_LENGTH_CAP = 20

--- a/taxonomy/algolia/serializers.py
+++ b/taxonomy/algolia/serializers.py
@@ -7,6 +7,7 @@ This module depends on serializers provided by django-rest-framework.
 
 from rest_framework import serializers
 
+from taxonomy.algolia.constants import EMBEDDED_OBJECT_LENGTH_CAP
 from taxonomy.models import Job, JobPostings, JobSkills
 
 
@@ -61,7 +62,8 @@ class JobSerializer(serializers.ModelSerializer):
         Arguments:
             obj (Job): Job instance whose skills need to be fetched.
         """
-        qs = JobSkills.objects.filter(job=obj).select_related('skill')
+        # We only need to fetch up-to 20 skills per job.
+        qs = JobSkills.objects.filter(job=obj).select_related('skill')[:EMBEDDED_OBJECT_LENGTH_CAP]
         serializer = JobSkillSerializer(qs, many=True)
         return serializer.data
 
@@ -72,7 +74,8 @@ class JobSerializer(serializers.ModelSerializer):
         Arguments:
             obj (Job): Job instance whose job postings need to be fetched.
         """
-        qs = JobPostings.objects.filter(job=obj)
+        # We only need to fetch up-to 20 job postings per job.
+        qs = JobPostings.objects.filter(job=obj)[:EMBEDDED_OBJECT_LENGTH_CAP]
         serializer = JobPostingSerializer(qs, many=True)
         return serializer.data
 

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -24,7 +24,7 @@ class SkillFactory(factory.django.DjangoModelFactory):
         model = Skill
         django_get_or_create = ('external_id', )
 
-    external_id = factory.LazyAttribute(lambda x: FAKER.slug())
+    external_id = factory.Sequence('SKILL-{}'.format)
     name = factory.LazyAttribute(lambda x: FAKER.job())
     info_url = factory.LazyAttribute(lambda x: FAKER.uri())
     type_id = factory.LazyAttribute(lambda x: FAKER.slug())
@@ -61,7 +61,7 @@ class JobFactory(factory.django.DjangoModelFactory):
 
         model = Job
 
-    external_id = factory.LazyAttribute(lambda x: FAKER.slug())
+    external_id = factory.Sequence('JOB-{}'.format)
     name = factory.LazyAttribute(lambda x: FAKER.job())
 
 


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.