### PR TITLE
build: enable the commitlint check for pull requests

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,10 @@
+# Run commitlint on the commit messages in a pull request.
+
+name: Lint Commit Messages
+
+on:
+  - pull_request
+
+jobs:
+  commitlint:
+    uses: edx/.github/.github/workflows/commitlint.yml@master


### PR DESCRIPTION
Check for conformance to OEP-51 (conventional commits).  This is not a required check, it will not prevent merging.  If you have concerns, let me know.